### PR TITLE
Improve customer UI design

### DIFF
--- a/resources/js/Components/BrandSection.jsx
+++ b/resources/js/Components/BrandSection.jsx
@@ -47,7 +47,7 @@ function BrandSection() {
                         key={tab.category_id}
                         id={`basic-tabs-${tab.category_id}`}
                         className={`${activeTab === tab.category_id ? '' : 'hidden'}
-                        grid grid-cols-10 max-md:grid-cols-6 sm:grid-cols-6 sm:gap-3 lg:grid-cols-10  max-sm:grid-cols-3 max-sm:gap-3`
+                        grid grid-cols-2 sm:grid-cols-3 md:grid-cols-4 lg:grid-cols-5 gap-4`
                     }
                         role="tabpanel"
                         aria-labelledby={`basic-tabs-item-${tab.category_id}`}
@@ -58,7 +58,7 @@ function BrandSection() {
                                 <div>
                                     <Link
                                         key={card.brand_id}
-                                        className="relative shadow-sm rounded-xl grid-cols-1 focus:outline-none focus:ring-2 focus:ring-secondary-500"
+                                        className="relative rounded-xl overflow-hidden shadow hover:shadow-lg transition-transform transform hover:-translate-y-1 focus:outline-none focus:ring-2 focus:ring-secondary-500"
                                         href={`/brand/${card.brand_id}`}
                                         style={{backdropFilter: 'blur(10px)'}} // Efek blur pada latar belakang
                                         onMouseEnter={() => setHoveredButton(index)}
@@ -73,10 +73,8 @@ function BrandSection() {
                                             alt={card.title}
                                         />
                                         {hoveredButton === index && (
-                                            <div className="absolute flex-col gap-4 rounded-xl border-secondary-500 border-4 inset-0 backdrop-blur flex items-center justify-center">
-                                                <img className='hidden dark:flex w-24 max-sm:w-10' src="/storage/logo_dark.png" alt="logo"/>
-                                                <img className='flex dark:hidden w-24 max-sm:w-10' src="/storage/logo_dark.png" alt="logo"/>
-                                                <h2 className='text-black dark:text-white text-center font-bold max-sm:hidden'>{card.brand_name}</h2>
+                                            <div className="absolute inset-0 rounded-xl bg-gradient-to-t from-black/70 to-transparent flex items-center justify-center">
+                                                <span className="px-4 py-2 bg-secondary-600 text-white text-sm font-semibold rounded-lg">Top Up Now</span>
                                             </div>
                                         )}
                                     </Link>

--- a/resources/js/Pages/GuestDashboard.jsx
+++ b/resources/js/Pages/GuestDashboard.jsx
@@ -31,6 +31,10 @@ export default function GuestDashboard(props) {
 
                 <div className="mx-auto max-w-7xl space-y-8 sm:px-6 lg:px-8 dark:text-white">
                     <CarouselHero/>
+                    <div className="text-center py-6">
+                        <h1 className="text-2xl sm:text-3xl font-bold text-primary-800 dark:text-white">Beli Voucher Game &amp; Pulsa Online</h1>
+                        <p className="text-primary-600 dark:text-neutral-300 mt-2">Transaksi cepat, aman dan terpercaya layaknya Codashop.</p>
+                    </div>
                     <BrandSection/>
 
                 <SigninModal />

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -29,10 +29,8 @@ export default {
                 sans: ['Figtree', ...defaultTheme.fontFamily.sans],
             },
             colors: {
-                'primary' : colors.blue,
-                'primary-dark' : colors.blue,
-                // 'primary' : colors.blue,
-                // 'primary-dark' : colors.blue,
+                'primary' : colors.orange,
+                'primary-dark' : colors.orange,
                 'secondary' : colors.lime,
                 'blue': {
                     '50': '#e8efff',


### PR DESCRIPTION
## Summary
- tweak brand grid with modern card style and Top Up overlay
- add hero text section to the guest dashboard
- switch primary theme color to orange

## Testing
- `npm install --legacy-peer-deps`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_b_686432de5318832faeea2b8976774bcb